### PR TITLE
Added support for running/stopping multiple instances

### DIFF
--- a/xray/ping.go
+++ b/xray/ping.go
@@ -12,7 +12,7 @@ import (
 // proxy means the local http/socks5 proxy, like "socks5://[::1]:1080".
 func Ping(datDir string, configPath string, timeout int, url string, proxy string) (int64, error) {
 	InitEnv(datDir)
-	server, err := StartXray(configPath)
+	server, err := StartXray(configPath, proxy)
 	if err != nil {
 		return nodep.PingDelayError, err
 	}

--- a/xray/validation.go
+++ b/xray/validation.go
@@ -5,7 +5,7 @@ package xray
 // configPath means the config.json file path.
 func TestXray(datDir string, configPath string) error {
 	InitEnv(datDir)
-	server, err := StartXray(configPath)
+	server, err := StartXray(configPath, configPath)
 	if err != nil {
 		return err
 	}

--- a/xray/xray.go
+++ b/xray/xray.go
@@ -3,6 +3,7 @@ package xray
 import (
 	"os"
 	"runtime/debug"
+	"sync"
 
 	"github.com/xtls/libxray/nodep"
 	"github.com/xtls/xray-core/common/cmdarg"
@@ -11,10 +12,12 @@ import (
 )
 
 var (
-	coreServer *core.Instance
+	// Map to store multiple server instances
+	serverInstances = make(map[string]*core.Instance)
+	serverMutex    sync.RWMutex
 )
 
-func StartXray(configPath string) (*core.Instance, error) {
+func StartXray(configPath string, tag string) (*core.Instance, error) {
 	file := cmdarg.Arg{configPath}
 	config, err := core.LoadConfig("json", file)
 	if err != nil {
@@ -25,6 +28,10 @@ func StartXray(configPath string) (*core.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	serverMutex.Lock()
+	serverInstances[tag] = server
+	serverMutex.Unlock()
 
 	return server, nil
 }
@@ -37,21 +44,19 @@ func setMaxMemory(maxMemory int64) {
 	nodep.InitForceFree(maxMemory, 1)
 }
 
-// Run Xray instance.
-// datDir means the dir which geosite.dat and geoip.dat are in.
-// configPath means the config.json file path.
-// maxMemory means the soft memory limit of golang, see SetMemoryLimit to find more information.
-func RunXray(datDir string, configPath string, maxMemory int64) (err error) {
+// Run Xray instance with a specific tag
+func RunXray(datDir string, configPath string, maxMemory int64, tag string) (err error) {
 	InitEnv(datDir)
 	if maxMemory > 0 {
 		setMaxMemory(maxMemory)
 	}
-	coreServer, err = StartXray(configPath)
+	
+	server, err := StartXray(configPath, tag)
 	if err != nil {
 		return
 	}
 
-	if err = coreServer.Start(); err != nil {
+	if err = server.Start(); err != nil {
 		return
 	}
 
@@ -59,16 +64,42 @@ func RunXray(datDir string, configPath string, maxMemory int64) (err error) {
 	return nil
 }
 
-// Stop Xray instance.
-func StopXray() error {
-	if coreServer != nil {
-		err := coreServer.Close()
-		coreServer = nil
+// Stop specific Xray instance
+func StopXrayInstance(tag string) error {
+	serverMutex.Lock()
+	defer serverMutex.Unlock()
+	
+	if server, exists := serverInstances[tag]; exists {
+		err := server.Close()
 		if err != nil {
 			return err
 		}
+		delete(serverInstances, tag)
 	}
 	return nil
+}
+
+// Stop all Xray instances
+func StopXray() error {
+	serverMutex.Lock()
+	defer serverMutex.Unlock()
+
+	for tag, server := range serverInstances {
+		err := server.Close()
+		if err != nil {
+			return err
+		}
+		delete(serverInstances, tag)
+	}
+	return nil
+}
+
+// Get specific Xray instance
+func GetXrayInstance(tag string) *core.Instance {
+	serverMutex.RLock()
+	defer serverMutex.RUnlock()
+	
+	return serverInstances[tag]
 }
 
 // Xray's version

--- a/xray_wrapper.go
+++ b/xray_wrapper.go
@@ -81,7 +81,7 @@ func CustomUUID(base64Text string) string {
 	return response.EncodeToBase64(uuid, nil)
 }
 
-type TestXrayRequest struct {
+type testXrayRequest struct {
 	DatDir     string `json:"datDir,omitempty"`
 	ConfigPath string `json:"configPath,omitempty"`
 }
@@ -93,7 +93,7 @@ func TestXray(base64Text string) string {
 	if err != nil {
 		return response.EncodeToBase64("", err)
 	}
-	var request TestXrayRequest
+	var request testXrayRequest
 	err = json.Unmarshal(req, &request)
 	if err != nil {
 		return response.EncodeToBase64("", err)
@@ -106,9 +106,10 @@ type runXrayRequest struct {
 	DatDir     string `json:"datDir,omitempty"`
 	ConfigPath string `json:"configPath,omitempty"`
 	MaxMemory  int64  `json:"maxMemory,omitempty"`
+	Tag        string `json:"tag,omitempty"`
 }
 
-// Run Xray instance.
+// Run Xray instance
 func RunXray(base64Text string) string {
 	var response nodep.CallResponse[string]
 	req, err := base64.StdEncoding.DecodeString(base64Text)
@@ -120,11 +121,24 @@ func RunXray(base64Text string) string {
 	if err != nil {
 		return response.EncodeToBase64("", err)
 	}
-	err = xray.RunXray(request.DatDir, request.ConfigPath, request.MaxMemory)
+	
+	// Use default tag if none provided
+	if request.Tag == "" {
+		request.Tag = "default"
+	}
+	
+	err = xray.RunXray(request.DatDir, request.ConfigPath, request.MaxMemory, request.Tag)
 	return response.EncodeToBase64("", err)
 }
 
-// Stop Xray instance.
+// Stop specific instance
+func StopXrayInstance(tag string) string {
+	var response nodep.CallResponse[string]
+	err := xray.StopXrayInstance(tag)
+	return response.EncodeToBase64("", err)
+}
+
+// StopXray now stops all instances
 func StopXray() string {
 	var response nodep.CallResponse[string]
 	err := xray.StopXray()


### PR DESCRIPTION
I have encountered a case where I need to run 2 or more xray instances. The community may find this useful.