### PR TITLE
Feature : in memoryy configg

### DIFF
--- a/xray/xray.go
+++ b/xray/xray.go
@@ -35,6 +35,19 @@ func StartXray(configPath string) (*core.Instance, error) {
 	return server, nil
 }
 
+func StartXrayFromJSON(configJSON string) (*core.Instance, error) {
+	// Convert JSON string to bytes
+	configBytes := []byte(configJSON)
+	
+	// Use core.StartInstance which can load configuration directly from bytes
+	server, err := core.StartInstance("json", configBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return server, nil
+}
+
 func InitEnv(datDir string) {
 	os.Setenv(coreAsset, datDir)
 	os.Setenv(coreCert, datDir)
@@ -47,6 +60,25 @@ func RunXray(datDir string, configPath string) (err error) {
 	InitEnv(datDir)
 	memory.InitForceFree()
 	coreServer, err = StartXray(configPath)
+	if err != nil {
+		return
+	}
+
+	if err = coreServer.Start(); err != nil {
+		return
+	}
+
+	debug.FreeOSMemory()
+	return nil
+}
+
+// Run Xray instance with JSON configuration string.
+// datDir means the dir which geosite.dat and geoip.dat are in.
+// configJSON means the JSON configuration string.
+func RunXrayFromJSON(datDir string, configJSON string) (err error) {
+	InitEnv(datDir)
+	memory.InitForceFree()
+	coreServer, err = StartXrayFromJSON(configJSON)
 	if err != nil {
 		return
 	}

--- a/xray_wrapper.go
+++ b/xray_wrapper.go
@@ -138,11 +138,31 @@ type RunXrayRequest struct {
 	ConfigPath string `json:"configPath,omitempty"`
 }
 
+type RunXrayFromJSONRequest struct {
+	DatDir     string `json:"datDir,omitempty"`
+	ConfigJSON string `json:"configJSON,omitempty"`
+}
+
 // Create Xray Run Request
 func NewXrayRunRequest(datDir, configPath string) (string, error) {
 	request := RunXrayRequest{
 		DatDir:     datDir,
 		ConfigPath: configPath,
+	}
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+
+	// Encode the JSON bytes to a base64 string
+	return base64.StdEncoding.EncodeToString(requestBytes), nil
+}
+
+// Create Xray Run From JSON Request
+func NewXrayRunFromJSONRequest(datDir, configJSON string) (string, error) {
+	request := RunXrayFromJSONRequest{
+		DatDir:     datDir,
+		ConfigJSON: configJSON,
 	}
 	requestBytes, err := json.Marshal(request)
 	if err != nil {
@@ -166,6 +186,22 @@ func RunXray(base64Text string) string {
 		return response.EncodeToBase64("", err)
 	}
 	err = xray.RunXray(request.DatDir, request.ConfigPath)
+	return response.EncodeToBase64("", err)
+}
+
+// Run Xray instance with JSON configuration.
+func RunXrayFromJSON(base64Text string) string {
+	var response nodep.CallResponse[string]
+	req, err := base64.StdEncoding.DecodeString(base64Text)
+	if err != nil {
+		return response.EncodeToBase64("", err)
+	}
+	var request RunXrayFromJSONRequest
+	err = json.Unmarshal(req, &request)
+	if err != nil {
+		return response.EncodeToBase64("", err)
+	}
+	err = xray.RunXrayFromJSON(request.DatDir, request.ConfigJSON)
 	return response.EncodeToBase64("", err)
 }
 


### PR DESCRIPTION
So this pr solves or enhances the issue #91 where they are concerned about like their config being stolen. I felt the same cause some attackers most of the time tries to get my config from the files directory where we write the temp config which is vulnerable in my view. So its a really great approach to solve the problem by just using in memory config and simplifies how we start xray , cause personally I hate it to write a config.json every time , its super boring !!!

Whatever now lets see how the pr solves the problem

so lets talk about the core functions that I have added firstly .

``` StartXrayFromJSON(configJSON string) (*core.Instance, error) ``` -> It creates a xray instance from the json config given to it. so in the main xray-core we have a function like this inside core package

```go
func StartInstance(configFormat string, configBytes []byte) (*Instance, error) {
	config, err := LoadConfig(configFormat, bytes.NewReader(configBytes))
	if err != nil {
		return nil, err
	}
	instance, err := New(config)
	if err != nil {
		return nil, err
	}
	if err := instance.Start(); err != nil {
		return nil, err
	}
	return instance, nil
}
```
what it does it takes the format (our case json and the config content in bytes) so when we deal normally with config.json file written in some location it uses the same function to process and get the instance by using the content bytes.  so in our ```StartXrayFromJSON(configJSON string) (*core.Instance, error)```  function we are writing a wrapper to that function simply thats it , no config.json file path related stuff required.   we get the json -> get bytes  and then send to the ```StartInstance()  ```then here comes the main function that the issue mentioned needed to included so its the function  ```RunXrayFromJSON(datDir string, configJSON string) (err error)```    it takes the datdir path and the configJson file content   then inits the env and simply starts the instance without involving any file writing so it works in memory.   these all are changes in xray.go  and in xray_wrapper.go I added wrapperss around these and some useful stuff like   ```RunXrayFromJSONRequest``` -> struct for the request with json ```   NewXrayRunFromJSONRequest(datDir, configJSON string) (string, error)```  -> for creating a request from json  and the actual ```RunXrayFromJSON(base64Text string)``` string which handles the connection.   so thats how I implemented or fixed the issue/feature/  feel free to do any counter questions, thanks ::::))))