### PR TITLE
Fix Windows ARM64 build toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,62 @@ jobs:
         run: go mod download
 
       # =========================
+      # Windows ARM64 toolchain
+      # =========================
+      - name: Install LLVM-MinGW for Windows ARM64
+        if: matrix.target == 'windows' && matrix.arch == 'arm64'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $headers = @{
+            Accept = "application/vnd.github+json"
+            Authorization = "Bearer $env:GH_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $release = Invoke-RestMethod `
+            -Headers $headers `
+            -Uri "https://api.github.com/repos/mstorsjo/llvm-mingw/releases/latest"
+          $asset = $release.assets |
+            Where-Object { $_.name -match "^llvm-mingw-.+-ucrt-aarch64\.zip$" } |
+            Select-Object -First 1
+          if ($null -eq $asset) {
+            throw "The latest LLVM-MinGW release has no ARM64 UCRT archive"
+          }
+
+          $archivePath = Join-Path $env:RUNNER_TEMP $asset.name
+          $extractPath = Join-Path $env:RUNNER_TEMP "llvm-mingw"
+          Write-Host "Downloading LLVM-MinGW $($release.tag_name): $($asset.name)"
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $archivePath
+          Expand-Archive -LiteralPath $archivePath -DestinationPath $extractPath
+
+          $binPath = Get-ChildItem -LiteralPath $extractPath -Directory |
+            ForEach-Object { Join-Path $_.FullName "bin" } |
+            Where-Object { Test-Path (Join-Path $_ "gcc.exe") } |
+            Select-Object -First 1
+          if ($null -eq $binPath) {
+            throw "LLVM-MinGW bin directory was not found in $extractPath"
+          }
+          $binPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Verify Windows ARM64 CGo toolchain
+        if: matrix.target == 'windows' && matrix.arch == 'arm64'
+        shell: pwsh
+        run: |
+          where.exe gcc.exe
+          where.exe g++.exe
+
+          $gccTarget = (& gcc.exe -dumpmachine).Trim()
+          $gxxTarget = (& g++.exe -dumpmachine).Trim()
+          $expectedTarget = '^aarch64-w64-(windows-gnu|mingw32)$'
+          if ($gccTarget -notmatch $expectedTarget) {
+            throw "Unexpected gcc target: $gccTarget"
+          }
+          if ($gxxTarget -notmatch $expectedTarget) {
+            throw "Unexpected g++ target: $gxxTarget"
+          }
+
+      # =========================
       # Apple toolchain
       # =========================
       - name: Select Xcode


### PR DESCRIPTION
## Summary

- install the latest LLVM-MinGW UCRT ARM64 toolchain for the Windows ARM64 build
- verify that `gcc` and `g++` target AArch64 before invoking the CGo build
- leave the Windows x64 and other platform jobs unchanged

## Root cause

The Windows ARM64 runner resolved an x64 GNU assembler, which could not assemble the AArch64 instructions in Go's `runtime/cgo/gcc_arm64.S`.

## Validation

- `git diff --check`
- parsed `.github/workflows/build.yml` as YAML
- Windows ARM64 compilation will be verified by GitHub Actions